### PR TITLE
Refresh MiniMax provider presets to current models and endpoints

### DIFF
--- a/src/api/hermes/types.ts
+++ b/src/api/hermes/types.ts
@@ -343,6 +343,13 @@ export interface HermesApiResponse<T = unknown> {
 
 // --- Provider 配置模板 ---
 
+export interface HermesProviderRegion {
+  region: string
+  openaiBaseUrl: string
+  anthropicBaseUrl: string
+  docsRoot: string
+}
+
 export interface HermesProviderConfig {
   id: string
   name: string
@@ -350,6 +357,9 @@ export interface HermesProviderConfig {
   envKey: string
   baseUrlKey?: string
   defaultBaseUrl?: string
+  // Anthropic-compatible endpoint configuration
+  anthropicBaseUrlKey?: string
+  defaultAnthropicBaseUrl?: string
   docsUrl?: string
   recommended?: boolean
   supportsModelList?: boolean
@@ -358,6 +368,8 @@ export interface HermesProviderConfig {
   modelsApiAuthType?: 'bearer' | 'x-api-key' | 'query' | 'none'
   modelsApiExtraHeaders?: Record<string, string>
   modelsApiQueryParam?: string
+  // Regional endpoint selection (global/CN)
+  regions?: HermesProviderRegion[]
 }
 
 export interface HermesCustomProvider {
@@ -443,11 +455,27 @@ export const HERMES_PROVIDERS: HermesProviderConfig[] = [
     name: 'MiniMax',
     envKey: 'MINIMAX_API_KEY',
     baseUrlKey: 'MINIMAX_BASE_URL',
-    defaultBaseUrl: 'https://api.minimax.chat/v1',
-    docsUrl: 'https://www.minimax.io/',
+    defaultBaseUrl: 'https://api.minimax.io/v1',
+    anthropicBaseUrlKey: 'MINIMAX_ANTHROPIC_BASE_URL',
+    defaultAnthropicBaseUrl: 'https://api.minimax.io/anthropic',
+    docsUrl: 'https://platform.minimax.io/docs',
     supportsModelList: true,
     modelsApiPath: '/models',
     modelsApiAuthType: 'bearer',
+    regions: [
+      {
+        region: 'global_en',
+        openaiBaseUrl: 'https://api.minimax.io/v1',
+        anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+        docsRoot: 'https://platform.minimax.io/docs',
+      },
+      {
+        region: 'cn_zh',
+        openaiBaseUrl: 'https://api.minimaxi.com/v1',
+        anthropicBaseUrl: 'https://api.minimaxi.com/anthropic',
+        docsRoot: 'https://platform.minimaxi.com/docs',
+      },
+    ],
   },
   {
     id: 'deepseek',

--- a/src/views/hermes/HermesModelsPage.vue
+++ b/src/views/hermes/HermesModelsPage.vue
@@ -606,7 +606,9 @@ const revealedKeys = ref<Set<string>>(new Set())
 const editingProvider = ref<HermesProviderConfig | null>(null)
 const showConfigForm = ref(false)
 const configFormApiKey = ref('')
+const configFormRegion = ref<string | null>(null)
 const configFormBaseUrl = ref('')
+const configFormAnthropicBaseUrl = ref('')
 const configFormModel = ref('')
 const configFormSaving = ref(false)
 const configFormModels = ref<{ id: string; name?: string }[]>([])
@@ -708,10 +710,38 @@ function getProviderDisplayBaseUrlValue(provider: HermesProviderConfig): string 
   return envVar.value
 }
 
+function getProviderAnthropicBaseUrlValue(provider: HermesProviderConfig): string {
+  if (!provider.anthropicBaseUrlKey) return provider.defaultAnthropicBaseUrl || ''
+  const envVar = modelStore.envVars.find((item) => item.key === provider.anthropicBaseUrlKey)
+  const rawVars = modelStore.rawEnvVars as Record<string, { is_set?: boolean; redacted_value?: string }> | null
+  if (envVar?.value?.trim()) return envVar.value
+  if (rawVars?.[provider.anthropicBaseUrlKey]?.is_set === true) {
+    return rawVars[provider.anthropicBaseUrlKey]!.redacted_value as string || provider.defaultAnthropicBaseUrl || ''
+  }
+  return provider.defaultAnthropicBaseUrl || ''
+}
+
+function syncConfigFormRegion(provider: HermesProviderConfig) {
+  const region = provider.regions?.find((item) => (
+    item.openaiBaseUrl === configFormBaseUrl.value.trim()
+    && item.anthropicBaseUrl === configFormAnthropicBaseUrl.value.trim()
+  ))
+  configFormRegion.value = region?.region || null
+}
+
+function handleConfigRegionChange(regionName: string) {
+  const region = editingProvider.value?.regions?.find((item) => item.region === regionName)
+  if (!region) return
+  configFormBaseUrl.value = region.openaiBaseUrl
+  configFormAnthropicBaseUrl.value = region.anthropicBaseUrl
+}
+
 async function handleOpenConfig(provider: HermesProviderConfig) {
   editingProvider.value = provider
   configFormApiKey.value = ''
   configFormBaseUrl.value = provider.defaultBaseUrl || ''
+  configFormAnthropicBaseUrl.value = provider.defaultAnthropicBaseUrl || ''
+  syncConfigFormRegion(provider)
   configFormModel.value = ''
   configFormModels.value = []
   showConfigForm.value = true
@@ -721,6 +751,8 @@ async function handleEditConfig(provider: HermesProviderConfig) {
   editingProvider.value = provider
   configFormApiKey.value = ''
   configFormBaseUrl.value = getProviderDisplayBaseUrlValue(provider)
+  configFormAnthropicBaseUrl.value = getProviderAnthropicBaseUrlValue(provider)
+  syncConfigFormRegion(provider)
   configFormModel.value = currentModelFromConfig.value || ''
   configFormModels.value = []
   const rawVars = modelStore.rawEnvVars as Record<string, { is_set?: boolean; redacted_value?: string }> | null
@@ -773,7 +805,9 @@ function handleCancelConfig() {
   editingProvider.value = null
   showConfigForm.value = false
   configFormApiKey.value = ''
+  configFormRegion.value = null
   configFormBaseUrl.value = ''
+  configFormAnthropicBaseUrl.value = ''
   configFormModel.value = ''
 }
 
@@ -788,6 +822,9 @@ async function handleSaveConfig() {
     }
     if (editingProvider.value.baseUrlKey && configFormBaseUrl.value.trim()) {
       await modelStore.setEnvVar(editingProvider.value.baseUrlKey, configFormBaseUrl.value.trim())
+    }
+    if (editingProvider.value.anthropicBaseUrlKey && configFormAnthropicBaseUrl.value.trim()) {
+      await modelStore.setEnvVar(editingProvider.value.anthropicBaseUrlKey, configFormAnthropicBaseUrl.value.trim())
     }
     
     // 如果选择了模型，设置为默认模型
@@ -834,10 +871,20 @@ async function handleDeleteConfig(provider: HermesProviderConfig) {
         await modelStore.deleteEnvVar(provider.baseUrlKey)
       }
     }
+    if (provider.anthropicBaseUrlKey) {
+      const anthropicBaseUrlVar = modelStore.envVars.find((item) => item.key === provider.anthropicBaseUrlKey)
+      const anthropicBaseUrlIsSet = anthropicBaseUrlVar?.value?.trim() || rawVars?.[provider.anthropicBaseUrlKey]?.is_set === true
+      if (anthropicBaseUrlVar && anthropicBaseUrlIsSet) {
+        await modelStore.deleteEnvVar(provider.anthropicBaseUrlKey)
+      }
+    }
     
     revealedKeys.value.delete(provider.envKey)
     if (provider.baseUrlKey) {
       revealedKeys.value.delete(provider.baseUrlKey)
+    }
+    if (provider.anthropicBaseUrlKey) {
+      revealedKeys.value.delete(provider.anthropicBaseUrlKey)
     }
     
     await modelStore.fetchEnvVars()
@@ -1638,9 +1685,20 @@ async function handleDeleteCustomProvider(providerName: string) {
             />
           </div>
 
+          <div v-if="editingProvider.regions && editingProvider.regions.length > 0">
+            <NText strong style="font-size: 14px; display: block; margin-bottom: 8px;">
+              Region
+            </NText>
+            <NSelect
+              v-model:value="configFormRegion"
+              :options="editingProvider.regions.map(region => ({ label: region.region, value: region.region }))"
+              @update:value="handleConfigRegionChange"
+            />
+          </div>
+
           <div v-if="editingProvider.baseUrlKey">
             <NText strong style="font-size: 14px; display: block; margin-bottom: 8px;">
-              Base URL
+              OpenAI-compatible Base URL
             </NText>
             <NText depth="3" style="font-size: 12px; display: block; margin-bottom: 8px;">
               {{ t('pages.hermesModels.providerConfig.baseUrlHint') }}
@@ -1649,24 +1707,19 @@ async function handleDeleteCustomProvider(providerName: string) {
               v-model:value="configFormBaseUrl"
               :placeholder="editingProvider.defaultBaseUrl || ''"
             />
-            <div v-if="editingProvider.regions && editingProvider.regions.length > 0" class="provider-region-hint">
-              <NText depth="3" style="font-size: 12px; display: block; margin-top: 8px;">
-                Regional endpoints (OpenAI-compatible / Anthropic-compatible):
-              </NText>
-              <div
-                v-for="region in editingProvider.regions"
-                :key="region.region"
-                class="provider-region-row"
-              >
-                <NTag size="small" :bordered="false" round>{{ region.region }}</NTag>
-                <code class="provider-region-url">{{ region.openaiBaseUrl }}</code>
-                <span style="color: var(--text-color-3);">·</span>
-                <code class="provider-region-url">{{ region.anthropicBaseUrl }}</code>
-              </div>
-              <NText v-if="editingProvider.defaultAnthropicBaseUrl" depth="3" style="font-size: 12px; display: block; margin-top: 4px;">
-                Default Anthropic endpoint: <code>{{ editingProvider.defaultAnthropicBaseUrl }}</code>
-              </NText>
-            </div>
+          </div>
+
+          <div v-if="editingProvider.anthropicBaseUrlKey">
+            <NText strong style="font-size: 14px; display: block; margin-bottom: 8px;">
+              Anthropic-compatible Base URL
+            </NText>
+            <NText depth="3" style="font-size: 12px; display: block; margin-bottom: 8px;">
+              Used by Anthropic-compatible clients for this provider.
+            </NText>
+            <NInput
+              v-model:value="configFormAnthropicBaseUrl"
+              :placeholder="editingProvider.defaultAnthropicBaseUrl || ''"
+            />
           </div>
 
           <div>
@@ -2416,23 +2469,6 @@ async function handleDeleteCustomProvider(providerName: string) {
   width: 100%;
   max-width: 480px;
   margin: 16px;
-}
-
-.provider-region-hint {
-  margin-top: 4px;
-}
-
-.provider-region-row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 4px;
-}
-
-.provider-region-url {
-  font-size: 12px;
-  word-break: break-all;
 }
 
 /* ---- Button hover animations ---- */

--- a/src/views/hermes/HermesModelsPage.vue
+++ b/src/views/hermes/HermesModelsPage.vue
@@ -1649,6 +1649,24 @@ async function handleDeleteCustomProvider(providerName: string) {
               v-model:value="configFormBaseUrl"
               :placeholder="editingProvider.defaultBaseUrl || ''"
             />
+            <div v-if="editingProvider.regions && editingProvider.regions.length > 0" class="provider-region-hint">
+              <NText depth="3" style="font-size: 12px; display: block; margin-top: 8px;">
+                Regional endpoints (OpenAI-compatible / Anthropic-compatible):
+              </NText>
+              <div
+                v-for="region in editingProvider.regions"
+                :key="region.region"
+                class="provider-region-row"
+              >
+                <NTag size="small" :bordered="false" round>{{ region.region }}</NTag>
+                <code class="provider-region-url">{{ region.openaiBaseUrl }}</code>
+                <span style="color: var(--text-color-3);">·</span>
+                <code class="provider-region-url">{{ region.anthropicBaseUrl }}</code>
+              </div>
+              <NText v-if="editingProvider.defaultAnthropicBaseUrl" depth="3" style="font-size: 12px; display: block; margin-top: 4px;">
+                Default Anthropic endpoint: <code>{{ editingProvider.defaultAnthropicBaseUrl }}</code>
+              </NText>
+            </div>
           </div>
 
           <div>
@@ -2398,6 +2416,23 @@ async function handleDeleteCustomProvider(providerName: string) {
   width: 100%;
   max-width: 480px;
   margin: 16px;
+}
+
+.provider-region-hint {
+  margin-top: 4px;
+}
+
+.provider-region-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.provider-region-url {
+  font-size: 12px;
+  word-break: break-all;
 }
 
 /* ---- Button hover animations ---- */

--- a/src/views/models/ModelsPage.vue
+++ b/src/views/models/ModelsPage.vue
@@ -2123,7 +2123,7 @@ async function handleQuickProviderSetup(key: QuickProviderKey) {
     } else if (key === 'minimax') {
       // MiniMax current models with full metadata (context, pricing, cache, input capabilities)
       const minimaxModels = [
-        { id: 'MiniMax-M3', name: 'MiniMax-M3', reasoning: true, input: ['text', 'image', 'video'], cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 }, contextWindow: 1000000 },
+        { id: 'MiniMax-M3', name: 'MiniMax-M3', reasoning: true, input: ['text', 'image', 'video'], cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: null }, contextWindow: 1000000 },
         { id: 'MiniMax-M2.7', name: 'MiniMax-M2.7', reasoning: true, input: ['text'], cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 }, contextWindow: 204800 },
       ]
       modelIds = minimaxModels.map(model => model.id)

--- a/src/views/models/ModelsPage.vue
+++ b/src/views/models/ModelsPage.vue
@@ -54,7 +54,7 @@ const confirmActionType = ref<'edit' | 'create'>('edit')
 const editActiveTab = ref<'basic' | 'models' | 'preview'>('basic')
 const createActiveTab = ref<'basic' | 'models' | 'preview'>('basic')
 
-type ModelInputType = 'text' | 'image'
+type ModelInputType = 'text' | 'image' | 'video'
 
 type ModelConfig = {
   id: string
@@ -65,6 +65,7 @@ type ModelConfig = {
 const modelInputTypeOptions = [
   { label: 'text', value: 'text' },
   { label: 'image', value: 'image' },
+  { label: 'video', value: 'video' },
 ]
 
 const DEFAULT_MODEL_INPUT_TYPES: ModelInputType[] = ['text']
@@ -107,11 +108,11 @@ const QUICK_PROVIDER_PRESETS: Record<QuickProviderKey, QuickProviderPreset> = {
     key: 'minimax',
     providerId: 'minimax',
     api: 'openai-completions',
-    baseUrl: 'https://api.minimaxi.com/v1',
-    modelId: 'MiniMax-M2.5',
-    modelName: 'MiniMax-M2.5',
-    input: ['text'],
-    docsUrl: 'https://platform.minimaxi.com/docs/api-reference/text-openai-api',
+    baseUrl: 'https://api.minimax.io/v1',
+    modelId: 'MiniMax-M3',
+    modelName: 'MiniMax-M3',
+    input: ['text', 'image', 'video'],
+    docsUrl: 'https://platform.minimax.io/docs',
   },
   bailian: {
     key: 'bailian',
@@ -295,7 +296,7 @@ function readProviderText(
 
 function normalizeModelInputTypes(value: unknown): ModelInputType[] {
   if (!Array.isArray(value)) return []
-  const allowed = new Set<ModelInputType>(['text', 'image'])
+  const allowed = new Set<ModelInputType>(['text', 'image', 'video'])
   const normalized = value
     .filter((item): item is string => typeof item === 'string')
     .map((item) => item.trim().toLowerCase())
@@ -441,7 +442,7 @@ function readProviderModels(provider: ModelProviderConfig | Record<string, unkno
       const id = (typeof model.id === 'string' && model.id.trim()) ||
         (typeof model.name === 'string' && model.name.trim()) || ''
       const input = Array.isArray(model.input)
-        ? model.input.filter((v): v is ModelInputType => v === 'text' || v === 'image')
+        ? model.input.filter((v): v is ModelInputType => v === 'text' || v === 'image' || v === 'video')
         : ['text'] as ModelInputType[]
       return { id, input, raw: model }
     }
@@ -2119,6 +2120,14 @@ async function handleQuickProviderSetup(key: QuickProviderKey) {
       ]
       modelIds = bailianModels.map(model => model.id)
       modelsConfig = bailianModels
+    } else if (key === 'minimax') {
+      // MiniMax current models with full metadata (context, pricing, cache, input capabilities)
+      const minimaxModels = [
+        { id: 'MiniMax-M3', name: 'MiniMax-M3', reasoning: true, input: ['text', 'image', 'video'], cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 }, contextWindow: 1000000 },
+        { id: 'MiniMax-M2.7', name: 'MiniMax-M2.7', reasoning: true, input: ['text'], cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 }, contextWindow: 204800 },
+      ]
+      modelIds = minimaxModels.map(model => model.id)
+      modelsConfig = minimaxModels
     } else {
       // 其他提供商保持现有行为
       modelIds = [preset.modelId]


### PR DESCRIPTION
Reason: Refresh the MiniMax quick-provider and Hermes presets to the current MiniMax-M3/M2.7 models, global endpoints, and Anthropic-compatible endpoint configuration.

Changes:
- Models quick-provider preset: switch the MiniMax preset from the obsolete CN-only `api.minimaxi.com/v1` endpoint and `MiniMax-M2.5` to the current global `api.minimax.io/v1` endpoint and `MiniMax-M3`, point docs to `platform.minimax.io/docs`, and declare `text/image/video` input modalities.
- Models quick-provider setup: provision both `MiniMax-M3` and `MiniMax-M2.7` with full metadata (context window, input/output/cache pricing, input capabilities, reasoning) instead of a single bare model id.
- Model input types: add `video` as a first-class model input type so MiniMax-M3's declared video input capability is represented.
- Hermes provider preset: replace the obsolete `api.minimax.chat/v1` default base URL with the current global `api.minimax.io/v1`, update docs to `platform.minimax.io/docs`, and expose the Anthropic-compatible endpoint (`api.minimax.io/anthropic`) plus global/CN regional endpoint selection (global `api.minimax.io`, CN `api.minimaxi.com`) on the provider config, rendered in the Base URL section of the Hermes models page.

Checks:
- `npx vue-tsc -b` (typecheck) passed with no errors.
